### PR TITLE
Add alpha channel to 4.17 and update the sequences to < and >

### DIFF
--- a/catalog/4.17/3scale-operator/catalog.json
+++ b/catalog/4.17/3scale-operator/catalog.json
@@ -13,8 +13,7 @@
     "package": "3scale-operator",
     "entries": [
         {
-            "name": "3scale-operator.v0.13.0",
-            "skipRange": "<0.12.2"
+            "name": "3scale-operator.v0.0.1"
         }
     ]
 }

--- a/catalog/4.17/catalog-template.json
+++ b/catalog/4.17/catalog-template.json
@@ -14,7 +14,7 @@
             "entries": [
                 {
                     "name": "3scale-operator.v0.10.5",
-                    "skipRange": "\u003e=0.9.1 \u003c0.10.5"
+                    "skipRange": ">=0.9.1 <0.10.5"
                 }
             ],
             "name": "threescale-2.13",
@@ -25,11 +25,11 @@
             "entries": [
                 {
                     "name": "3scale-operator.v0.12.0",
-                    "skipRange": "\u003e=0.11.0 \u003c0.12.0"
+                    "skipRange": ">=0.11.0 <0.12.0"
                 },
                 {
                     "name": "3scale-operator.v0.12.1",
-                    "skipRange": "\u003e=0.11.0 \u003c0.12.1",
+                    "skipRange": ">=0.11.0 <0.12.1",
                     "skips": [
                         "3scale-operator.v0.12.0"
                     ]
@@ -84,7 +84,7 @@
                 {
                     "name": "3scale-operator.v0.12.1-mas",
                     "replaces": "3scale-operator.v0.11.8-mas",
-                    "skipRange": "\u003e=0.11.8 \u003c0.12.1"
+                    "skipRange": ">=0.11.8 <0.12.1"
                 }
             ],
             "name": "threescale-mas",
@@ -94,8 +94,7 @@
         {
             "entries": [
                 {
-                    "name": "3scale-operator.v0.13.0",
-                    "skipRange": "\u003c0.12.2"
+                    "name": "3scale-operator.v0.0.1"
                 }
             ],
             "name": "alpha",


### PR DESCRIPTION
Adds alpha channel ( 0.0.1 ) to 4.17.
Remove 2.16 (0.13.0) from 4.17 - reason for that is that I had no bundle for 2.16 and same bundle can't be used more than once.

# Verification

Run:
```
opm validate ./catalog/4.17/3scale-operator/
```
No errors should be reported.